### PR TITLE
upgrade composer to fix security vulnerability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,6 @@
     "vlucas/phpdotenv": ">=3.3.3"
   },
   "require-dev": {
-    "composer/composer": "^1.10 || ^2.1"
+    "composer/composer": "^1.10.23 || ^2.1.9"
   }
 }


### PR DESCRIPTION
upgrade composer to at least 1.10.23 or 2.1.9 to eliminate a vulnerability. Severity limited, because it is in the 'dev' requirements.