### PR TITLE
Rename into impresscms/composer-addon-installer-plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "impresscms/composer-module-installer-plugin",
+  "name": "impresscms/composer-addon-installer-plugin",
   "description": "This plugin allows the installation of ImpressCMS addons from composer",
   "minimum-stability": "dev",
   "license": "MIT",


### PR DESCRIPTION
This plugin can install not only modules but also translations and themes, so I think it would be good idea to rename it.

@fiammybe this pull request needs your attention, because you are only one who can do these steps to end:

1. Accept this pull request
2. Rename this repo into `composer-addon-installer-plugin`
3. [Submit new repo to packagist.org](https://packagist.org/packages/submit)
4. Mark old package as abanoned at https://packagist.org/packages/impresscms/composer-module-installer-plugin
5. Add to old package new package as replacement